### PR TITLE
Fix tag format causing crash issues

### DIFF
--- a/setuphelpers.py
+++ b/setuphelpers.py
@@ -279,11 +279,13 @@ def _lastest_tag():
     """Gets the latest git tag according to PEP440."""
 
     latest_tag = parse_version("0.0.0")
+    return_tag = "0.0.0"
     for tag in check_output(["git", "tag"]).splitlines():
         tag_version = parse_version(_decoded(tag))
         if tag_version > latest_tag:
             latest_tag = tag_version
-    return latest_tag.public
+            return_tag = tag
+    return return_tag
 
 
 def _tag_ref(git_tag):

--- a/setuphelpers.py
+++ b/setuphelpers.py
@@ -284,7 +284,7 @@ def _lastest_tag():
         tag_version = parse_version(_decoded(tag))
         if tag_version > latest_tag:
             latest_tag = tag_version
-            return_tag = tag
+            return_tag = _decoded(tag)
     return return_tag
 
 


### PR DESCRIPTION
The regex in parse_version() can cause the "public" response to be different than the original tag.   The result of this is that the tag returned by _lastest_tag() can be an invalid tag for git - crashing the version calculator.   This fixes the crash.